### PR TITLE
Adds Github actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build Image
+
+on:
+  pull_request:
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    name: Docker Image
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish-docker:
     runs-on: ubuntu-latest
-    name: Docker Image
+    name: Build Docker
 
     steps:
       - name: Checkout source

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-docker:
     runs-on: ubuntu-latest
-    name: Docker Image
+    name: Publish Docker
 
     environment:
       name: ghcr
@@ -26,8 +26,8 @@ jobs:
         with:
           images: ghcr.io/sedonaprice/uncover_dv
           tags: |
-            type=sha
             type=raw,value=latest
+            type=raw,value=${{ github.sha }}
           labels: |
             org.opencontainers.image.title="JWST Uncover"
             org.opencontainers.image.description="Web frontend for the JWST Uncover project."
@@ -36,7 +36,7 @@ jobs:
             org.opencontainers.image.authors="The JWST Uncover Team"
             org.opencontainers.image.revision="${{ github.sha }}"
             org.opencontainers.image.vendor="University of Pittsburgh"
-            org.opencontainers.image.ref.name="ghcr.io/sedonaprice/uncover_dv:${{ inputs.version }}"
+            org.opencontainers.image.ref.name="ghcr.io/sedonaprice/uncover_dv:${{ github.sha }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    name: Docker Image
+
+    environment:
+      name: ghcr
+      url: https://github.com/sedonaprice/UNCOVER_DV_web/pkgs/container/uncover_dv
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Define Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: ghcr.io/sedonaprice/uncover_dv
+          tags: |
+            type=sha
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title="JWST Uncover"
+            org.opencontainers.image.description="Web frontend for the JWST Uncover project."
+            org.opencontainers.image.url="https://github.com/sedonaprice/UNCOVER_DV_web"
+            org.opencontainers.image.source="https://github.com/sedonaprice/UNCOVER_DV_web"
+            org.opencontainers.image.authors="The JWST Uncover Team"
+            org.opencontainers.image.revision="${{ github.sha }}"
+            org.opencontainers.image.vendor="University of Pittsburgh"
+            org.opencontainers.image.ref.name="ghcr.io/sedonaprice/uncover_dv:${{ inputs.version }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Adds automated workflows for monitoring dependencies and building/publishing the docker image. 

The `dependabot.yml` file configures GitHub Dependabot to submit a PR every month updating project dependecies to the latest versions. When coupled with automated tests, this is a convenient way to automate security patches applied to dependencies. 

The `build.yml` file runs a test build of the docker file on pull requests. Its a simple workflow, but can be reworked into a testing workflow later on.

The `publish.yml` file builds and publishes the image to GHCR every time main is updated. It tags the image with the git commit hash along with the tag `latest`. Metadata is added to the image for best practice sake. I've also configured the workflow to use Qemu which runs the build on a virtualized architecture. This allows the workflow to publish x86 and ARM compatible images.

The publish workflow should work as is, but there is a chance it needs some small debugging post merge depending on the parent repo settings. 